### PR TITLE
fix: Return Firebase APIKEYS

### DIFF
--- a/src/Firebase/firebase.js
+++ b/src/Firebase/firebase.js
@@ -2,12 +2,12 @@ import firebase from 'firebase/app'
 import 'firebase/auth'
 
 const config = {
-   apiKey: process.env.REACT_APP_FIREBASE_APIKEY,
-   authDomain: process.env.REACT_APP_AUTHDOMAIN,
-   databaseURL: process.env.REACT_APP_DATABASEURL,
-   projectId: process.env.REACT_APP_PROJECTID,
-   storageBucket: process.env.REACT_APP_FIREBASE_STORAGEBUCKET,
-   messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGINGSENDERID
+   apiKey: "AIzaSyBWx4XW1s0Y4UgDneZL8V0ZFYr1Sc4YKvk",
+   authDomain: "myself-calculator.firebaseapp.com",
+   databaseURL: "https://myself-calculator.firebaseio.com",
+   projectId: "projectId",
+   storageBucket: "myself-calculator.appspot.com",
+   messagingSenderId: "1043096824390"
 }
 
 firebase.initializeApp(config);


### PR DESCRIPTION
## Issue
#9 

## Overview
FirebaseのAPIKEY達を`.env`ファイルに分けたら、herokuにアップロードした際に嫁込めなくなったため、`.env`ファイルを削除し、APIKEYを`firebase.js`に戻しました。